### PR TITLE
Se arregló el carrusel de imágenes para que muestre solo la cantidad …

### DIFF
--- a/proyecto-grupal/client/src/components/CarouselImg/CarouselImg.jsx
+++ b/proyecto-grupal/client/src/components/CarouselImg/CarouselImg.jsx
@@ -13,8 +13,18 @@ export default function CarouselImg () {
       
     return (
     
-      <Carousel style={{width: "29rem"}}>
-      <Carousel.Item>
+      <Carousel style={{ width: "29rem" }}>
+        {detail.images && detail.images.map((img) => {
+          return (<Carousel.Item>
+            <img
+              className="d-block w-100"
+              src={img}
+              alt="First slide"
+            />
+          </Carousel.Item>
+          )
+        })}
+      {/* <Carousel.Item>
         <img
           className="d-block w-100"
           src={detail.images[0]}
@@ -48,7 +58,7 @@ export default function CarouselImg () {
           src={detail.images[4]}
           alt="First slide"
         />
-      </Carousel.Item>
+      </Carousel.Item> */}
       
     </Carousel>
        


### PR DESCRIPTION
Se arregló el carrusel de imágenes para que muestre solo la cantidad de imágenes que tiene el detalle del producto y no siempre 5 aunque no haya 5 imágenes (Ejemplo, un producto con dos imágenes mostraba 5 elementos en el carrusel, las dos primeras correctas y los últimos 3 vacíos. Ahora mostraría solo 2). También se pueden agregar más de 5.